### PR TITLE
Update to the latest versions of slang and Vulkan-headers

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,12 +1,12 @@
 <project toolsVersion="6.0">
-    <remote name="github-slang-windows" type="https" packageLocation="github.com/shader-slang/slang/releases/download/v${version}/slang-${version}-win64.zip"/>
+    <remote name="github-slang-windows" type="https" packageLocation="github.com/shader-slang/slang/releases/download/v${version}/slang-${version}-windows-x86_64.zip"/>
     <remote name="github-slang-linux" type="https" packageLocation="github.com/shader-slang/slang/releases/download/v${version}/slang-${version}-linux-x86_64.zip"/>
     <dependency name="slang" linkPath="external/packman/slang">
-        <package name="slang" version="2024.0.6" remotes="github-slang-windows" platforms="windows-x86_64"/>
-        <package name="slang" version="2024.0.6" remotes="github-slang-linux" platforms="linux-x86_64" />
+        <package name="slang" version="2025.6.2" remotes="github-slang-windows" platforms="windows-x86_64"/>
+        <package name="slang" version="2025.6.2" remotes="github-slang-linux" platforms="linux-x86_64" />
     </dependency>
     <remote name="vulkan-headers" type="https" packageLocation="github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${version}.zip"/>
     <dependency name="vulkan-headers" linkPath="external/packman/vulkan">
-        <package name="vulkan-headers" version="1.3.275" remotes="vulkan-headers"/>
+        <package name="vulkan-headers" version="1.4.310" remotes="vulkan-headers"/>
     </dependency>
 </project>

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -22,14 +22,14 @@ set_property(CACHE FALCOR_SLANG_CONFIG PROPERTY STRINGS release debug)
 if(FALCOR_WINDOWS)
     add_library(slang SHARED IMPORTED GLOBAL)
     set_target_properties(slang PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}
-        IMPORTED_IMPLIB ${SLANG_DIR}/bin/windows-x64/${FALCOR_SLANG_CONFIG}/slang.lib
-        IMPORTED_LOCATION ${SLANG_DIR}/bin/windows-x64/${FALCOR_SLANG_CONFIG}/slang.dll
+        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}/include
+        IMPORTED_IMPLIB ${SLANG_DIR}/lib/slang.lib
+        IMPORTED_LOCATION ${SLANG_DIR}/bin/slang.dll
     )
 elseif(FALCOR_LINUX)
     add_library(slang SHARED IMPORTED GLOBAL)
     set_target_properties(slang PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}
+        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}/include
         IMPORTED_LOCATION ${SLANG_DIR}/bin/linux-x64/${FALCOR_SLANG_CONFIG}/libslang.so
     )
 endif()
@@ -38,17 +38,17 @@ endif()
 if(FALCOR_WINDOWS)
     add_library(slang-gfx SHARED IMPORTED GLOBAL)
     set_target_properties(slang-gfx PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}
-        IMPORTED_IMPLIB ${SLANG_DIR}/bin/windows-x64/${FALCOR_SLANG_CONFIG}/gfx.lib
-        IMPORTED_LOCATION ${SLANG_DIR}/bin/windows-x64/${FALCOR_SLANG_CONFIG}/gfx.dll
+        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}/include
+        IMPORTED_IMPLIB ${SLANG_DIR}/lib/gfx.lib
+        IMPORTED_LOCATION ${SLANG_DIR}/bin/gfx.dll
     )
 elseif(FALCOR_LINUX)
     add_library(slang-gfx SHARED IMPORTED GLOBAL)
     set_target_properties(slang-gfx PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}
+        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}/include
         IMPORTED_LOCATION ${SLANG_DIR}/bin/linux-x64/${FALCOR_SLANG_CONFIG}/libgfx.so
     )
 endif()
 
-set(VULKAN_DIR ${PACKMAN_DIR}/vulkan/Vulkan-Headers-1.3.275)
+set(VULKAN_DIR ${PACKMAN_DIR}/vulkan/Vulkan-Headers-1.4.310)
 target_include_directories(external_includes INTERFACE ${VULKAN_DIR}/include)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -30,7 +30,7 @@ elseif(FALCOR_LINUX)
     add_library(slang SHARED IMPORTED GLOBAL)
     set_target_properties(slang PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}/include
-        IMPORTED_LOCATION ${SLANG_DIR}/bin/linux-x64/${FALCOR_SLANG_CONFIG}/libslang.so
+        IMPORTED_LOCATION ${SLANG_DIR}/lib/libslang.so
     )
 endif()
 
@@ -46,7 +46,7 @@ elseif(FALCOR_LINUX)
     add_library(slang-gfx SHARED IMPORTED GLOBAL)
     set_target_properties(slang-gfx PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${SLANG_DIR}/include
-        IMPORTED_LOCATION ${SLANG_DIR}/bin/linux-x64/${FALCOR_SLANG_CONFIG}/libgfx.so
+        IMPORTED_LOCATION ${SLANG_DIR}/lib/libgfx.so
     )
 endif()
 

--- a/source/shaders/Utils/Math/FormatConversion.slang
+++ b/source/shaders/Utils/Math/FormatConversion.slang
@@ -248,6 +248,7 @@ float2 unpackSnorm2x16(uint packed)
     return unpacked;
 }
 
+#if 0
 /**
  * Pack two floats into 16-bit snorm values in the lo/hi bits of a dword.
  * @return Two 16-bit snorm in low/high bits.
@@ -256,6 +257,7 @@ uint packSnorm2x16(precise float2 v)
 {
     return (floatToSnorm16(v.x) & 0x0000ffff) | (floatToSnorm16(v.y) << 16);
 }
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 //                              16-bit unorm
@@ -282,6 +284,7 @@ uint packUnorm16(float v)
     return packUnorm16_unsafe(v);
 }
 
+#if 0
 /**
  * Pack two floats into 16-bit unorm values in a dword.
  */
@@ -289,6 +292,7 @@ uint packUnorm2x16(float2 v)
 {
     return (packUnorm16(v.y) << 16) | packUnorm16(v.x);
 }
+#endif
 
 /**
  * Pack two floats into 16-bit unorm values in a dword (unsafe version)


### PR DESCRIPTION
Fix the duplicated function definition problem and update the versions to the latest.